### PR TITLE
Bump from checkout@v2 to v4

### DIFF
--- a/.github/workflows/ee-test-with-oauth2.yml
+++ b/.github/workflows/ee-test-with-oauth2.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
`checkout@v2` has been deprecated. This PR updates it to v4.

https://github.com/gee-community/ee-initialize-github-actions/actions/runs/11355372379
![image](https://github.com/user-attachments/assets/2b63fec4-90b3-4e0b-bd95-f1ece7af0a33)

